### PR TITLE
Memory viewer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,8 @@ set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 
 set(camus_VERSION_MAJOR 0)
-set(camus_VERSION_MINOR 1)
-set(camus_VERSION_PATCH 2)
+set(camus_VERSION_MINOR 2)
+set(camus_VERSION_PATCH 0)
 set(camus_VERSION ${camus_VERSION_MAJOR}.${camus_VERSION_MINOR}.${camus_VERSION_PATCH})
 
 project(camus

--- a/include/gui.h
+++ b/include/gui.h
@@ -13,7 +13,8 @@ enum camus_gui_open {
 	MENUBAR	  = PANEL(0),
 	REGISTERS = PANEL(1),
 	SPEED	  = PANEL(2),
-	ABOUT	  = PANEL(3)
+	ABOUT	  = PANEL(3),
+	MEMORY	  = PANEL(4)
 };
 typedef u32 camus_gui_flags;
 

--- a/include/gui/memory.h
+++ b/include/gui/memory.h
@@ -1,0 +1,8 @@
+#ifndef MEMORY_H
+#define MEMORY_H
+
+#include <gui.h>
+
+extern bool camus_gui_memory(struct camus_gui* restrict g);
+
+#endif

--- a/include/util/hex.h
+++ b/include/util/hex.h
@@ -3,6 +3,6 @@
 
 #include <util/types.h>
 
-extern void u16_to_hex(u16 num, char* str, u8 group_size);
+extern void u16_to_hex(u16 num, char* restrict str, u8 group_size);
 
 #endif

--- a/include/util/hex.h
+++ b/include/util/hex.h
@@ -1,0 +1,8 @@
+#ifndef HEX_H
+#define HEX_H
+
+#include <util/types.h>
+
+extern void u16_to_hex(u16 num, char* str, u8 group_size);
+
+#endif

--- a/include/util/types.h
+++ b/include/util/types.h
@@ -7,4 +7,8 @@ typedef uint8_t	 u8;
 typedef uint16_t u16;
 typedef uint32_t u32;
 
+typedef int8_t	i8;
+typedef int16_t i16;
+typedef int32_t i32;
+
 #endif

--- a/src/gui.c
+++ b/src/gui.c
@@ -7,6 +7,7 @@
 #include <gui/menubar.h>
 #include <gui/registers.h>
 #include <gui/about.h>
+#include <gui/memory.h>
 
 #define MAX_VERTEX_MEMORY  512 * 1024
 #define MAX_ELEMENT_MEMORY 128 * 1024
@@ -46,6 +47,7 @@ void camus_gui_update(struct camus_gui* restrict g) {
 	UPDATE_PANEL(MENUBAR, camus_gui_menubar)
 	UPDATE_PANEL(REGISTERS, camus_gui_registers)
 	UPDATE_PANEL(ABOUT, camus_gui_about)
+	UPDATE_PANEL(MEMORY, camus_gui_memory)
 }
 
 void camus_gui_draw(struct camus_gui* restrict g) {

--- a/src/gui/memory.c
+++ b/src/gui/memory.c
@@ -3,38 +3,42 @@
 #define NAME "Memory"
 
 bool camus_gui_memory(struct camus_gui* restrict g) {
-	if (nk_begin(g->ctx, NAME, nk_rect(50, 50, 580, 600), NK_WINDOW_BORDER | NK_WINDOW_MOVABLE | NK_WINDOW_CLOSABLE | NK_WINDOW_NO_SCROLLBAR)) {
+	if (nk_begin(g->ctx, NAME, nk_rect(50, 50, 350, 400), NK_WINDOW_BORDER | NK_WINDOW_MOVABLE | NK_WINDOW_CLOSABLE | NK_WINDOW_NO_SCROLLBAR)) {
 		const struct nk_rect total_space   = nk_window_get_content_region(g->ctx);
 		const float			 panel_padding = g->ctx->style.window.padding.x;
 
-		nk_layout_row_begin(g->ctx, NK_STATIC, 10, 0xF + 1);
+		nk_layout_row_begin(g->ctx, NK_STATIC, 10, 1 + 0x8);
 		{
 			nk_layout_row_push(g->ctx, 35 + panel_padding);
 			nk_spacing(g->ctx, 1);
 
 			for (u8 i = 0; i <= 0xF; i += 2) {
-				char hex[2 + 1 + 1];
-				sprintf(hex, "%02X ", i);
-				nk_layout_row_push(g->ctx, 60 + panel_padding);
+				char hex[2 + 1];
+				sprintf(hex, "%02X", i);
+
+				nk_layout_row_push(g->ctx, 30);
 				nk_label(g->ctx, hex, NK_TEXT_ALIGN_LEFT);
 			}
 		}
 		nk_layout_row_end(g->ctx);
 
-		nk_layout_row_static(g->ctx, total_space.h - panel_padding, total_space.w, 1);
+		nk_layout_row_static(g->ctx, total_space.h - panel_padding * 2, total_space.w, 1);
 		if (nk_group_begin(g->ctx, "Contents", 0)) {
-			nk_layout_row_begin(g->ctx, NK_STATIC, 10, 0xF + 1);
+			nk_layout_row_begin(g->ctx, NK_STATIC, 10, 1 + 0x8);
 			{
-				for (u16 i = 0; i < MEM_SIZE; ++i) {
-					char hex[4 + 1 + 1];
+				for (u16 i = 1; i < MEM_SIZE + 1; i += 2) {
+					char hex[4 + 1];
 
-					if (i % 0x10 == 0) {
+					if ((i - 1) % 0x10 == 0) {
 						nk_layout_row_push(g->ctx, 35);
-						sprintf(hex, "%04X ", i);
-					} else {
-						nk_layout_row_push(g->ctx, 30);
-						sprintf(hex, "%04X ", g->c->mem[i] | g->c->mem[i + 1] << 8);
+						sprintf(hex, "%04X", i - 1);
+
+						nk_label(g->ctx, hex, NK_TEXT_ALIGN_LEFT);
 					}
+
+					nk_layout_row_push(g->ctx, 30);
+					sprintf(hex, "%04X", g->c->mem[i - 1] << 8 | g->c->mem[i]);
+
 					nk_label(g->ctx, hex, NK_TEXT_ALIGN_LEFT);
 				}
 			}

--- a/src/gui/memory.c
+++ b/src/gui/memory.c
@@ -1,0 +1,49 @@
+#include <gui/memory.h>
+
+#define NAME "Memory"
+
+bool camus_gui_memory(struct camus_gui* restrict g) {
+	if (nk_begin(g->ctx, NAME, nk_rect(50, 50, 580, 600), NK_WINDOW_BORDER | NK_WINDOW_MOVABLE | NK_WINDOW_CLOSABLE | NK_WINDOW_NO_SCROLLBAR)) {
+		const struct nk_rect total_space   = nk_window_get_content_region(g->ctx);
+		const float			 panel_padding = g->ctx->style.window.padding.x;
+
+		nk_layout_row_begin(g->ctx, NK_STATIC, 10, 0xF + 1);
+		{
+			nk_layout_row_push(g->ctx, 35 + panel_padding);
+			nk_spacing(g->ctx, 1);
+
+			for (u8 i = 0; i <= 0xF; i += 2) {
+				char hex[2 + 1 + 1];
+				sprintf(hex, "%02X ", i);
+				nk_layout_row_push(g->ctx, 60 + panel_padding);
+				nk_label(g->ctx, hex, NK_TEXT_ALIGN_LEFT);
+			}
+		}
+		nk_layout_row_end(g->ctx);
+
+		nk_layout_row_static(g->ctx, total_space.h - panel_padding, total_space.w, 1);
+		if (nk_group_begin(g->ctx, "Contents", 0)) {
+			nk_layout_row_begin(g->ctx, NK_STATIC, 10, 0xF + 1);
+			{
+				for (u16 i = 0; i < MEM_SIZE; ++i) {
+					char hex[4 + 1 + 1];
+
+					if (i % 0x10 == 0) {
+						nk_layout_row_push(g->ctx, 35);
+						sprintf(hex, "%04X ", i);
+					} else {
+						nk_layout_row_push(g->ctx, 30);
+						sprintf(hex, "%04X ", g->c->mem[i] | g->c->mem[i + 1] << 8);
+					}
+					nk_label(g->ctx, hex, NK_TEXT_ALIGN_LEFT);
+				}
+			}
+			nk_layout_row_end(g->ctx);
+
+			nk_group_end(g->ctx);
+		}
+	}
+	nk_end(g->ctx);
+
+	return !(nk_window_is_hidden(g->ctx, NAME) || nk_window_is_closed(g->ctx, NAME));
+}

--- a/src/gui/memory.c
+++ b/src/gui/memory.c
@@ -1,4 +1,5 @@
 #include <gui/memory.h>
+#include <util/hex.h>
 
 #define NAME "Memory"
 
@@ -14,7 +15,7 @@ bool camus_gui_memory(struct camus_gui* restrict g) {
 
 			for (u8 i = 0; i <= 0xF; i += 2) {
 				char hex[2 + 1];
-				sprintf(hex, "%02X", i);
+				u16_to_hex(i, hex, 2);
 
 				nk_layout_row_push(g->ctx, 30);
 				nk_label(g->ctx, hex, NK_TEXT_ALIGN_LEFT);
@@ -31,14 +32,13 @@ bool camus_gui_memory(struct camus_gui* restrict g) {
 
 					if ((i - 1) % 0x10 == 0) {
 						nk_layout_row_push(g->ctx, 35);
-						sprintf(hex, "%04X", i - 1);
+						u16_to_hex(i - 1, hex, 4);
 
 						nk_label(g->ctx, hex, NK_TEXT_ALIGN_LEFT);
 					}
 
+					u16_to_hex(g->c->mem[i - 1] << 8 | g->c->mem[i], hex, 4);
 					nk_layout_row_push(g->ctx, 30);
-					sprintf(hex, "%04X", g->c->mem[i - 1] << 8 | g->c->mem[i]);
-
 					nk_label(g->ctx, hex, NK_TEXT_ALIGN_LEFT);
 				}
 			}

--- a/src/gui/menubar.c
+++ b/src/gui/menubar.c
@@ -50,6 +50,7 @@ bool camus_gui_menubar(struct camus_gui* restrict g) {
 			if (nk_menu_begin_label(g->ctx, "Debug", NK_TEXT_LEFT, nk_vec2(120, 200))) {
 				nk_layout_row_dynamic(g->ctx, 20, 1);
 				PANEL(REGISTERS, "Registers")
+				PANEL(MEMORY, "Memory")
 				nk_menu_end(g->ctx);
 			}
 

--- a/src/util/hex.c
+++ b/src/util/hex.c
@@ -1,6 +1,6 @@
 #include <util/hex.h>
 
-void u16_to_hex(u16 num, char* str, u8 group_size) {
+void u16_to_hex(u16 num, char* restrict str, u8 group_size) {
 	static const char* charset = "0123456789ABCDEF";
 
 	for (i8 i = group_size - 1; i >= 0; --i) {

--- a/src/util/hex.c
+++ b/src/util/hex.c
@@ -1,0 +1,12 @@
+#include <util/hex.h>
+
+void u16_to_hex(u16 num, char* str, u8 group_size) {
+	static const char* charset = "0123456789ABCDEF";
+
+	for (i8 i = group_size - 1; i >= 0; --i) {
+		str[i] = charset[num & 0xF];
+		num /= 0x10;
+	}
+
+	str[group_size] = '\0';
+}


### PR DESCRIPTION
Closes #13 
Currently it allocates `char` buffers and calls `u16_to_hex` every frame, which is pretty inefficient.